### PR TITLE
Github Actions tests of playbook

### DIFF
--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Test on python ${{ matrix.node_version }} and ${{ matrix.os }}
+    name: Test on python ${{ matrix.python_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.9', '3.10']
+        python_version: ['3.9', '3.10', '3.11']
         os: [ubuntu-22.04, ubuntu-20.04]
 
 
@@ -26,6 +26,4 @@ jobs:
           ansible-galaxy install -r tests/requirements.yml
       - name: Run playbook
         run: |
-          ls -lah ../
           ansible-playbook tests/test.yml -i tests/inventory
-          

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -32,4 +32,4 @@ jobs:
           command: ansible-galaxy install -r tests/requirements.yml
       - name: Run playbook
         run: |
-          ansible-playbook tests/test.yml -i tests/inventory
+          ansible-playbook tests/test-gha.yml -i tests/inventory

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install ansible-galaxy requirements
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 15
+          timeout_seconds: 180
           max_attempts: 3
           retry_on: error
           command: ansible-galaxy install -r tests/requirements.yml

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip3 install ansible
+          printf '[defaults]\nroles_path=../' >ansible.cfg
           ansible-galaxy install -r tests/requirements.yml
       - name: Run playbook
         run: |
           ls -lah ../
-          printf '[defaults]\nroles_path=../' >ansible.cfg
           ansible-playbook tests/test.yml -i tests/inventory
           

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -1,0 +1,31 @@
+name: ansible-role-snipe-it
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test on python ${{ matrix.node_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python_version: ['3.9', '3.10']
+        os: [ubuntu-22.04, ubuntu-20.04]
+
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install ansible
+          ansible-galaxy install -r tests/requirements.yml
+      - name: Run playbook
+        run: |
+          ls -lah ../
+          printf '[defaults]\nroles_path=../' >ansible.cfg
+          ansible-playbook tests/test.yml -i tests/inventory
+          

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -23,7 +23,13 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install ansible
           printf '[defaults]\nroles_path=../' >ansible.cfg
-          ansible-galaxy install -r tests/requirements.yml
+      - name: Install ansible-galaxy requirements
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 15
+          max_attempts: 3
+          retry_on: error
+          command: ansible-galaxy install -r tests/requirements.yml
       - name: Run playbook
         run: |
           ansible-playbook tests/test.yml -i tests/inventory

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -16,6 +16,8 @@
 
 - name: Delete anonymous user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: ""
     host_all: true
     state: absent
@@ -23,6 +25,8 @@
 
 - name: Delete hostname-based root user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: root
     host: "{{ ansible_nodename }}"
     state: absent
@@ -30,18 +34,24 @@
 
 - name: Remove test database
   community.mysql.mysql_db:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: test
     state: absent
   become: true
 
 - name: Create snipeit database
   community.mysql.mysql_db:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: "{{ snipe_db_database }}"
     state: present
   become: true
 
 - name: Create snipeit user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: "{{ snipe_db_username }}"
     password: "{{ snipe_db_password }}"
     priv: "{{ snipe_db_database }}.*:ALL"

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: nginxinc.nginx

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,1 +1,2 @@
-- src: nginxinc.nginx
+collections:
+  - name: nginxinc.nginx_core

--- a/tests/test-gha.yml
+++ b/tests/test-gha.yml
@@ -1,0 +1,25 @@
+---
+- hosts: localhost
+  connection: local
+  remote_user: root
+  roles:
+    - ansible-role-snipe-it
+
+  tasks:
+  - name: Remove default vhost in nginx
+    ansible.builtin.file:
+      path: /etc/nginx/conf.d/default.conf
+      state: absent
+    become: true
+
+  - name: Make sure nginx service is restarted
+    ansible.builtin.systemd:
+      state: restarted
+      name: nginx
+    become: true
+
+  - name: Test reachability of /setup
+    ansible.builtin.uri:
+      url: "http://localhost/setup"
+      method: GET
+    register: _result

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,25 +1,6 @@
 ---
 - hosts: localhost
-  connection: local
   remote_user: root
   roles:
-    - ansible-role-snipe-it
-
-  tasks:
-  - name: Remove default vhost in nginx
-    ansible.builtin.file:
-      path: /etc/nginx/conf.d/default.conf
-      state: absent
-    become: true
-
-  - name: Make sure nginx service is restarted
-    ansible.builtin.systemd:
-      state: restarted
-      name: nginx
-    become: true
-
-  - name: Test reachability of /setup
-    ansible.builtin.uri:
-      url: "http://localhost/setup"
-      method: GET
-    register: _result
+    - snipeit
+    

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -18,9 +18,6 @@
       name: nginx
     become: true
 
-  - name: Execute lsof 
-    ansible.builtin.shell: sudo lsof -i -P
-
   - name: Test reachability of /setup
     ansible.builtin.uri:
       url: "http://localhost/setup"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  connection: local
   remote_user: root
   roles:
     - snipeit

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,4 +3,4 @@
   connection: local
   remote_user: root
   roles:
-    - snipeit
+    - ansible-role-snipe-it

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,3 +4,10 @@
   remote_user: root
   roles:
     - ansible-role-snipe-it
+
+  tasks:
+  - name: Test reachability of /setup
+    ansible.builtin.uri:
+      url: "http://localhost/setup"
+      method: GET
+    register: _result

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,11 +10,13 @@
     ansible.builtin.file:
       path: /etc/nginx/conf.d/default.conf
       state: absent
+    become: true
 
   - name: Make sure nginx service is restarted
     ansible.builtin.systemd:
       state: restarted
       name: nginx
+    become: true
 
   - name: Execute lsof 
     ansible.builtin.shell: sudo lsof -i -P

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,19 @@
     - ansible-role-snipe-it
 
   tasks:
+  - name: Remove default vhost in nginx
+    ansible.builtin.file:
+      path: /etc/nginx/conf.d/default.conf
+      state: absent
+
+  - name: Make sure nginx service is restarted
+    ansible.builtin.systemd:
+      state: restarted
+      name: nginx
+
+  - name: Execute lsof 
+    ansible.builtin.shell: sudo lsof -i -P
+
   - name: Test reachability of /setup
     ansible.builtin.uri:
       url: "http://localhost/setup"


### PR DESCRIPTION
This introduces a testsuite for the playbook run itself on Ubuntu 22.04 and 20.04 for three python versions.

Some notes on some of my choices:

re: .`github/workflows/ansible-playbook.yml`
I decided to use `nick-fields/retry@v2` for the ansible-galaxy install because it would randomly fail. This will retry the install thrice before failing for just this specific step.

re: `tasks/mysql.yml`
As the Github Actions Ubuntu images include a mysql server, I had to add the user/password for this as an "omit" parameter to the mysql tasks.

I have tested this separately on another Ubuntu vm, and it works as expected, where the parameter gets omitted if not run inside Github Actions. (as evidenced by the 'GITHUB_ACTIONS' environment variable)

re: `tests/test-gha.yml`
Since its a very minimal setup of snipe, the default vhost of the nginx install is kept at localhost, which also means that we need to remove the default.conf that is shipped with nginx to actually be able to reach our snipe-it install via localhost.

I am open to ideas, if you have a better idea than to simply test if the /setup uri returns a 200 http response code.